### PR TITLE
Public cards page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Home from "./pages/Home";
 import NotFound from "./pages/NotFound";
 import ClassDetail from "./pages/ClassDetail";
 import TeacherDashboard from "./pages/TeacherDashboard";
+import PublicCards from "./pages/PublicCards";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
@@ -58,6 +59,7 @@ const App = () => (
             <Route exact path="/class/:id" component={ClassDetail} />
             <Route exact path="/teacher" component={TeacherDashboard} />
             <Route exact path="/teacher/class/:id" component={ClassDetail} />
+            <Route exact path="/public-cards" component={PublicCards} />
             <Route component={NotFound} />
           </IonRouterOutlet>
         </IonReactRouter>

--- a/src/pages/PublicCards.tsx
+++ b/src/pages/PublicCards.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Plus } from "lucide-react";
+import { Link } from "react-router-dom";
+
+const PublicFlashcards = () => {
+  const flashcardSets = [
+    { id: 1, title: "Basic Spanish Vocabulary", creator: "John Doe", cards: 50 },
+    { id: 2, title: "World Capitals", creator: "Jane Smith", cards: 30 },
+    { id: 3, title: "Biology Terms", creator: "Dr. Emily Brown", cards: 40 },
+  ];
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">Public Flashcards</h1>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {flashcardSets.map((set) => (
+          <Card key={set.id}>
+            <CardHeader>
+              <CardTitle>{set.title}</CardTitle>
+              <CardDescription>Created by {set.creator}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-gray-600">{set.cards} cards</p>
+              <Button variant="link" asChild className="mt-2 p-0">
+                <Link to={`/flashcards/${set.id}`}>View Set →</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PublicFlashcards;


### PR DESCRIPTION
Added a page that will be used to make the public sets available to all users. The current endpoint is /public-cards. I have not added any way to navigate to this page from any of the exisiting screens. We need to discuss how this page should be accessed whether from a nav bar we add or something else.
@Woody-14 