### PR TITLE
fix dark mode of Reset Password and Confirm Reset Password pages

### DIFF
--- a/src/components/auth/ConfirmResetPass.tsx
+++ b/src/components/auth/ConfirmResetPass.tsx
@@ -128,7 +128,7 @@ const ConfirmResetPass = () => {
   return (
     <IonPage>
       <IonContent>
-        <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="flex items-center justify-center min-h-screen">
           <Card className="w-[350px]">
             <CardHeader>
               <CardTitle>Reset Your Password</CardTitle>

--- a/src/components/auth/ResetPass.tsx
+++ b/src/components/auth/ResetPass.tsx
@@ -98,7 +98,7 @@ const ResetPass = () => {
   return (
     <IonPage>
       <IonContent>
-        <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="flex items-center justify-center min-h-screen">
           <Card className="w-11/12 max-w-[350px]">
             <CardHeader>
               <CardTitle className="text-4xl tracking-wide font-smokum font-bold">


### PR DESCRIPTION
fixed background color on dark modeof ResetPass and ConfirmResetPass by removing a un-needed HTML attribute